### PR TITLE
NPE fix

### DIFF
--- a/src/main/java/org/zalando/twintip/spring/SchemaResource.java
+++ b/src/main/java/org/zalando/twintip/spring/SchemaResource.java
@@ -66,7 +66,7 @@ public class SchemaResource {
         });
         this.enableCors = enableCors;
 
-        if (!baseUrl.isEmpty()) {
+        if (baseUrl != null && !baseUrl.isEmpty()) {
             updateApiUrl(node, URI.create(baseUrl));
         }
     }


### PR DESCRIPTION
In our project default behaviour of property resolving amended to use null instead empty string. Thus ${twintip.baseUrl:} becames null.